### PR TITLE
Update scroll to top btn colour & profile pic button

### DIFF
--- a/app/assets/stylesheets/components/_scroll_top_btn.scss
+++ b/app/assets/stylesheets/components/_scroll_top_btn.scss
@@ -18,7 +18,7 @@
   }
 
 	.fa-chevron-circle-up {
-		color: $dark-blue;
+		color: $light-blue;
     opacity: 0.8;
 	}
 
@@ -26,7 +26,7 @@
     text-decoration: none;
 
 		.fa-chevron-circle-up {
-			color: $dark-blue;
+			color: $light-blue;
       opacity: 1;
 		}
 	}

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -23,7 +23,14 @@
             <%= f.input :password_confirmation,
                         required: false,
                         input_html: { autocomplete: "new-password" } %>
-            <%= f.input :photo, as: :file, label: 'Upload Profile Picture (Optional)' %>
+            <div class="add-photo d-flex align-items-start mb-3">
+              <%= image_tag "", width: 150, class: "d-none mr-2", id: "photo-preview" %>
+              <%= f.input :photo,
+                          as: :file,
+                          label: '📷 Upload Profile Image',
+                          input_html: { class: "d-none" },
+                          label_html: { class: "upload-photo" } %>
+            </div>
             <%= f.input :current_password,
                         hint: "we need your current password to confirm your changes",
                         required: true,


### PR DESCRIPTION
- Changed scroll to top button to light blue for better visibility.
<img width="1276" alt="Screenshot 2022-01-12 at 10 05 35 PM" src="https://user-images.githubusercontent.com/86341373/149155347-0ef045cf-147e-4f26-aeb8-fbae18bf3f65.png">

- Changed upload profile pic button on edit profile page.
<img width="590" alt="Screenshot 2022-01-12 at 10 06 18 PM" src="https://user-images.githubusercontent.com/86341373/149155369-9c29504a-9d25-4e6d-9691-9ec2e5e66a40.png">
